### PR TITLE
Ethereum Classic Monetary Policy

### DIFF
--- a/ethcore/res/ethereum/classic.json
+++ b/ethcore/res/ethereum/classic.json
@@ -16,6 +16,7 @@
 				"eip160Transition": 3000000,
 				"ecip1010PauseTransition": 3000000,
 				"ecip1010ContinueTransition": 5000000,
+                "ecip1017EraRounds": 5000000,
 
 				"eip161abcTransition": "0x7fffffffffffffff",
 				"eip161dTransition": "0x7fffffffffffffff"

--- a/json/src/spec/ethash.rs
+++ b/json/src/spec/ethash.rs
@@ -100,6 +100,10 @@ pub struct EthashParams {
 	#[serde(rename="ecip1010ContinueTransition")]
 	pub ecip1010_continue_transition: Option<Uint>,
 
+    /// See main EthashParams docs.
+    #[serde(rename="ecip1017EraRounds")]
+    pub ecip1017_era_rounds: Option<Uint>,
+
 	/// See main EthashParams docs.
 	#[serde(rename="maxCodeSize")]
 	pub max_code_size: Option<Uint>,


### PR DESCRIPTION
Create a new parameter `ecip1017EraRounds`. When the block number
passes one era rounds, the reward is reduced by 20%.

See https://github.com/ethereumproject/ECIPs/blob/master/ECIPs/ECIP-1017.md